### PR TITLE
feat: automate release

### DIFF
--- a/.github/workflows/patch_update_release.yml
+++ b/.github/workflows/patch_update_release.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Checkout your repository
       uses: actions/checkout@v4
       with:
+        token: ${{ secrets.PAT }}
         fetch-depth: 0
 
     - name: Set up Git identity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Runner CD
 on:
   workflow_dispatch:
   push:
+    branches:
+    - releases/**
     paths:
     - releaseVersion
 


### PR DESCRIPTION
Run the release workflow on push to any branch prefixed with `releases/`.
The release workflow actions is supposed to be triggered when the patch sync is successful: https://github.com/canonical/github-actions-runner/blob/main/.github/workflows/patch_update_release.yml#L149-L154

A GitHub PAT should be used for actions/checkout for any subsequent pushes to trigger the `on: push` workflow in the repository. See: https://github.com/orgs/community/discussions/37103

