### PR TITLE
fix: automated pr workflow

### DIFF
--- a/.github/workflows/patch_update_main.yml
+++ b/.github/workflows/patch_update_main.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Checkout your repository
       uses: actions/checkout@v4
       with:
+        token: ${{ secrets.PAT }}
         fetch-depth: 0
 
     - name: Set up Git identity
@@ -142,7 +143,7 @@ jobs:
       uses: canonical/create-pull-request@main
       if: steps.process-arches.outputs.successful_arches != ''
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.PAT }}
         commit-message: "Update patches: ${{ steps.get-commits.outputs.PREVIOUS_COMMIT_SHORT }} → ${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }} [${{ steps.process-arches.outputs.successful_arches }}]"
         branch-name: patch-sync/${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }}
         title: Sync main patch ${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }}

--- a/.github/workflows/patch_update_main.yml
+++ b/.github/workflows/patch_update_main.yml
@@ -16,6 +16,8 @@ jobs:
     - name: Checkout your repository
       uses: actions/checkout@v4
       with:
+        # 2025-08-22: Using GitHub's Personal Access Token is required to allow automated workflow
+        # triggers (on: pull_request) from Pull Requests issued by this workflow.
         token: ${{ secrets.PAT }}
         fetch-depth: 0
 
@@ -143,6 +145,8 @@ jobs:
       uses: canonical/create-pull-request@main
       if: steps.process-arches.outputs.successful_arches != ''
       with:
+        # 2025-08-22: Using GitHub's Personal Access Token is required to allow automated workflow
+        # triggers (on: pull_request) from Pull Requests issued by this workflow.
         github-token: ${{ secrets.PAT }}
         commit-message: "Update patches: ${{ steps.get-commits.outputs.PREVIOUS_COMMIT_SHORT }} → ${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }} [${{ steps.process-arches.outputs.successful_arches }}]"
         branch-name: patch-sync/${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }}

--- a/.github/workflows/patch_update_release.yml
+++ b/.github/workflows/patch_update_release.yml
@@ -16,6 +16,8 @@ jobs:
     - name: Checkout your repository
       uses: actions/checkout@v4
       with:
+        # 2025-08-22: Using GitHub's Personal Access Token is required to allow automated workflow
+        # triggers (on: pull_request) from Pull Requests issued by this workflow.
         token: ${{ secrets.PAT }}
         fetch-depth: 0
 
@@ -136,6 +138,8 @@ jobs:
       uses: canonical/create-pull-request@main
       if: steps.process-arches.outputs.successful_arches != ''
       with:
+        # 2025-08-22: Using GitHub's Personal Access Token is required to allow automated workflow
+        # triggers (on: pull_request) from Pull Requests issued by this workflow.
         github-token: ${{ secrets.PAT }}
         commit-message: "Update release: ${{ steps.get-tags.outputs.PREVIOUS_TAG }} → ${{ steps.get-tags.outputs.LATEST_TAG }} [${{ steps.process-arches.outputs.successful_arches }}]"
         branch-name: patch-release-sync/${{ steps.get-tags.outputs.LATEST_TAG }}

--- a/.github/workflows/patch_update_release.yml
+++ b/.github/workflows/patch_update_release.yml
@@ -136,7 +136,7 @@ jobs:
       uses: canonical/create-pull-request@main
       if: steps.process-arches.outputs.successful_arches != ''
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.PAT }}
         commit-message: "Update release: ${{ steps.get-tags.outputs.PREVIOUS_TAG }} → ${{ steps.get-tags.outputs.LATEST_TAG }} [${{ steps.process-arches.outputs.successful_arches }}]"
         branch-name: patch-release-sync/${{ steps.get-tags.outputs.LATEST_TAG }}
         title: Sync release patch ${{ steps.get-tags.outputs.LATEST_TAG }}


### PR DESCRIPTION
Current PRs created by the automated action does not trigger PR workflows.
This is due to [GitHub's efforts to prevent infinite loops](https://github.com/orgs/community/discussions/55906) on workflows being triggered.
Switching to PAT should suffice in allowing the Bot PR to start build workflow checks, which is necessary to ensure that the patched binary works.

Tested on my own repository that PAT triggered PR runs the desired workflows:
<img width="1023" height="407" alt="image" src="https://github.com/user-attachments/assets/de2323b4-16ed-4b9e-af30-83fb56766193" />
