### PR TITLE
fix: pe bot verified commit

### DIFF
--- a/.github/workflows/patch_update_main.yml
+++ b/.github/workflows/patch_update_main.yml
@@ -16,15 +16,7 @@ jobs:
     - name: Checkout your repository
       uses: actions/checkout@v4
       with:
-        # 2025-08-22: Using GitHub's Personal Access Token is required to allow automated workflow
-        # triggers (on: pull_request) from Pull Requests issued by this workflow.
-        token: ${{ secrets.PAT }}
         fetch-depth: 0
-
-    - name: Set up Git identity
-      run: |
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "actions@github.com"
 
     - name: Clone upstream runner repository
       run: |
@@ -141,14 +133,25 @@ jobs:
         cd upstream-runner && git checkout ${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }} && cd ..
         cp -r upstream-runner/* .
 
+    - name: Import and configure the GPG key for Platform Engineering bot
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ secrets.PE_BOT_GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.PE_BOT_GPG_PASSKEY }}
+        git_config_global: true
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+
     - name: Create pull request
-      uses: canonical/create-pull-request@main
+      uses: peter-evans/create-pull-request@v6
       if: steps.process-arches.outputs.successful_arches != ''
       with:
         # 2025-08-22: Using GitHub's Personal Access Token is required to allow automated workflow
         # triggers (on: pull_request) from Pull Requests issued by this workflow.
-        github-token: ${{ secrets.PAT }}
+        token: ${{ secrets.PE_BOT_PAT }}
         commit-message: "Update patches: ${{ steps.get-commits.outputs.PREVIOUS_COMMIT_SHORT }} → ${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }} [${{ steps.process-arches.outputs.successful_arches }}]"
-        branch-name: patch-sync/${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }}
+        committer: Platform Engineering Bot <is-devops-team@canonical.com>
+        author: Platform Engineering Bot <is-devops-team@canonical.com>
+        branch: patch-sync/${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }}
         title: Sync main patch ${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }}
         body: Sync main branch patcdh for commit ${{ steps.get-commits.outputs.LATEST_COMMIT_SHORT }}

--- a/.github/workflows/patch_update_main.yml
+++ b/.github/workflows/patch_update_main.yml
@@ -137,7 +137,7 @@ jobs:
       uses: crazy-max/ghaction-import-gpg@v6
       with:
         gpg_private_key: ${{ secrets.PE_BOT_GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.PE_BOT_GPG_PASSKEY }}
+        passphrase: ${{ secrets.PE_BOT_GPG_PASSPHRASE }}
         git_config_global: true
         git_user_signingkey: true
         git_commit_gpgsign: true

--- a/.github/workflows/patch_update_release.yml
+++ b/.github/workflows/patch_update_release.yml
@@ -16,15 +16,7 @@ jobs:
     - name: Checkout your repository
       uses: actions/checkout@v4
       with:
-        # 2025-08-22: Using GitHub's Personal Access Token is required to allow automated workflow
-        # triggers (on: pull_request) from Pull Requests issued by this workflow.
-        token: ${{ secrets.PAT }}
         fetch-depth: 0
-
-    - name: Set up Git identity
-      run: |
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "actions@github.com"
 
     - name: Clone upstream runner repository
       run: git clone --tags https://github.com/actions/runner.git upstream-runner
@@ -134,17 +126,28 @@ jobs:
       run: |
         rm -f successful_arches.txt
 
+            - name: Import and configure the GPG key for Platform Engineering bot
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ secrets.PE_BOT_GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.PE_BOT_GPG_PASSKEY }}
+        git_config_global: true
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+
     - name: Create pull request to main
-      uses: canonical/create-pull-request@main
+      uses: peter-evans/create-pull-request@v6
       if: steps.process-arches.outputs.successful_arches != ''
       with:
         # 2025-08-22: Using GitHub's Personal Access Token is required to allow automated workflow
         # triggers (on: pull_request) from Pull Requests issued by this workflow.
-        github-token: ${{ secrets.PAT }}
-        commit-message: "Update release: ${{ steps.get-tags.outputs.PREVIOUS_TAG }} → ${{ steps.get-tags.outputs.LATEST_TAG }} [${{ steps.process-arches.outputs.successful_arches }}]"
-        branch-name: patch-release-sync/${{ steps.get-tags.outputs.LATEST_TAG }}
-        title: Sync release patch ${{ steps.get-tags.outputs.LATEST_TAG }}
-        body: Sync release branch patch for commit ${{ steps.get-tags.outputs.LATEST_TAG }}
+        token: ${{ secrets.PE_BOT_PAT }}
+        commit-message: "Update release: ${{ steps.get-commits.outputs.PREVIOUS_TAG }} → ${{ steps.get-commits.outputs.LATEST_TAG }} [${{ steps.process-arches.outputs.successful_arches }}]"
+        committer: Platform Engineering Bot <is-devops-team@canonical.com>
+        author: Platform Engineering Bot <is-devops-team@canonical.com>
+        branch: patch-sync/${{ steps.get-commits.outputs.LATEST_TAG }}
+        title: Sync release patch ${{ steps.get-commits.outputs.LATEST_TAG }}
+        body: Sync release branch patch for commit ${{ steps.get-commits.outputs.LATEST_TAG }}
 
     - name: Prepare repo for release
       run: |

--- a/.github/workflows/patch_update_release.yml
+++ b/.github/workflows/patch_update_release.yml
@@ -130,7 +130,7 @@ jobs:
       uses: crazy-max/ghaction-import-gpg@v6
       with:
         gpg_private_key: ${{ secrets.PE_BOT_GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.PE_BOT_GPG_PASSKEY }}
+        passphrase: ${{ secrets.PE_BOT_GPG_PASSPHRASE }}
         git_config_global: true
         git_user_signingkey: true
         git_commit_gpgsign: true


### PR DESCRIPTION
### Changes

This workflow updates to use GPG signed commits using the `Platform Engineering Bot` account (previously IS-DevOps-Bot).

### Rationale

Using GitHub's `secrets.GITHUB_TOKEN` disallows triggering of the PR workflows which is necessary to make sure that the binary is tested before being released.
Using just the `secrets.PAT` creates an unsigned commit, which is necessary to merge changes with Canonical's policies.

### Notes

The idea was taken from observability team's workflow: https://github.com/canonical/observability/blob/main/.github/workflows/charm-update-libs.yaml#L133-L157

PLEASE REMEMBER TO DELETE (deprecate) the PAT secret under settings/secrets after this has been merged. The secrets have been renamed to follow better naming standards.

### Testing

Testing has been performed under a private repository to confirm:
1. The commit is signed
2. The workflow is triggered

<img width="1182" height="584" alt="image" src="https://github.com/user-attachments/assets/6a9fdc8f-7945-4df0-b54e-a2c1cdc6993f" />
