### PR TITLE
ci: add pull-requests write permission to bot_pr_approval workflow

### DIFF
--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -1,7 +1,13 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 name: Provide approval for bot PRs
 
 on:
   pull_request:
+
+permissions:
+  pull-requests: write
 
 jobs:
   bot_pr_approval:


### PR DESCRIPTION
## Problem

The `bot_pr_approval` workflow fails with:

```
Error: HttpError: Resource not accessible by integration
```

See: https://github.com/canonical/github-actions-runner/actions/runs/26260949343/job/77294025695?pr=149

## Root cause

The reusable workflow at `canonical/operator-workflows` uses `GITHUB_TOKEN` to approve bot PRs via `pulls.createReview`. Without an explicit `permissions` block in the caller workflow, the token doesn't have write access to pull-requests.

## Fix

Add `permissions: pull-requests: write` to the caller workflow so the inherited token has the required scope.