### PR TITLE
ci(release): auto-trigger Runner CD on release-branch push

### DIFF
--- a/.github/workflows/patch_update_release.yml
+++ b/.github/workflows/patch_update_release.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Persist the PE bot PAT (not the default GITHUB_TOKEN) so the
+          # release-branch push triggers Runner CD (release.yml). Pushes
+          # authenticated with GITHUB_TOKEN do not trigger downstream workflows.
+          token: ${{ secrets.PE_BOT_PAT }}
 
       - name: Clone upstream runner repository
         run: git clone --tags https://github.com/actions/runner.git upstream-runner
@@ -163,7 +167,7 @@ jobs:
         if: steps.process-arches.outputs.successful_arches != ''
         run: |
           git checkout -b releases/${{ steps.get-tags.outputs.LATEST_TAG }}
-          git add . && git commit -m "Create release ${{steps.get-tags.outputs.LATEST_TAG}}"
+          git add . && git commit -m "Create release ${{ steps.get-tags.outputs.LATEST_TAG }}"
           git push -u origin releases/${{ steps.get-tags.outputs.LATEST_TAG }}
 
       - uses: mattermost/action-mattermost-notify@master


### PR DESCRIPTION
## Summary

The release-branch creation in `patch_update_release.yml` pushes the new `releases/<tag>` branch using the default `GITHUB_TOKEN` (persisted by `actions/checkout`). Pushes authenticated with `GITHUB_TOKEN` do **not** trigger downstream workflows, so `release.yml` (Runner CD) never fires automatically — every release has required a manual `workflow_dispatch`.

This persists `secrets.PE_BOT_PAT` as the checkout credential instead, so the release-branch push triggers Runner CD automatically. This mirrors the existing fix already applied to the `create-pull-request` step (see the 2025-08-22 comment), which the release-branch push was never given.

## Changes

- `actions/checkout` now uses `token: ${{ secrets.PE_BOT_PAT }}` so pushes authenticate as the bot PAT and trigger downstream workflows.
- Release-branch push left as a plain `git push origin` (PAT comes from the persisted credential, avoiding the `http.extraheader` override that defeats a URL-embedded token).
- Minor: normalized whitespace in the `Create release` commit-message expression.

## Notes

- Does not retroactively release **v2.335.1**: its `releases/v2.335.1` branch already exists, so no new push will fire CD. That one still needs a one-time manual *Runner CD* `workflow_dispatch` against `releases/v2.335.1`.
- Tradeoff: the PAT now authenticates all git operations in that job (only the release-branch push actually needs it; the PR step uses its own token).