### PR TITLE
ci: run linux-arm release Test package in arm32v7 container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           runs_on: arm64
 
         - runtime: linux-arm
-          runs_on: arm
+          runs_on: arm64
           patch_tag: arm
 
     runs-on: [ self-hosted, noble, "${{ matrix.runs_on }}" ]
@@ -107,13 +107,31 @@ jobs:
       working-directory: src
 
     - name: Test package
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' && matrix.runtime != 'linux-arm'
       run: |
         mkdir package_test
         tar -xvzf ../_package/*.tar.gz -C package_test
         ./package_test/config.sh --version
       working-directory: src
-        
+
+    # linux-arm produces armv7l (32-bit) binaries that cannot execute on the
+    # arm64 build host directly, so smoke-test the package inside a 32-bit arm container.
+    # On arm64 hosts with native AArch32 support this runs natively; if binfmt/qemu-user
+    # emulation is configured on the runner, it may run under emulation instead.
+    - name: Test package (arm32v7 container)
+      if: github.event_name != 'pull_request' && matrix.runtime == 'linux-arm'
+      run: |
+        mkdir package_test
+        tar -xzf ../_package/*.tar.gz -C package_test
+        # Use sudo only if the runner user can't reach the Docker daemon directly.
+        DOCKER=docker
+        if ! docker info >/dev/null 2>&1; then DOCKER="sudo docker"; fi
+        $DOCKER run --rm --platform linux/arm/v7 \
+          -e RUNNER_ALLOW_RUNASROOT=1 \
+          -v "$(pwd)/package_test:/runner" -w /runner \
+          arm32v7/ubuntu:noble \
+          bash -c 'set -e; apt-get update -qq; DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libicu74 libatomic1 ca-certificates >/dev/null; ./config.sh --version'
+      working-directory: src
 
     # compute shas and set as job outputs to use in release notes
     - run: |


### PR DESCRIPTION
## Problem

Runner CD (`release.yml`) can't publish the `linux-arm` asset on the existing
infrastructure. The `linux-arm` build was scheduled on a **dedicated 32-bit arm
self-hosted runner**:

```yaml
- runtime: linux-arm
  runs_on: arm        # → runs-on: [ self-hosted, noble, arm ]
```

and ran `./package_test/config.sh --version` **directly**. That requires an
armhf runner to already exist in the pool — a chicken-and-egg problem, since
publishing this asset is exactly what bootstraps armhf runners.

(This is the same failure class fixed for Runner CI in #169; that PR only
touched `build.yml`, leaving `release.yml` broken.)

## Fix

Mirror the #169 approach in `release.yml`:

- Build `linux-arm` on the **arm64 self-hosted pool** (`runs_on: arm64`).
- Split the **Test package** step:
  - non-arm runtimes run `config.sh --version` directly (unchanged);
  - `linux-arm` smoke-tests the packaged **armv7l** binary inside an
    `arm32v7/ubuntu:noble` container. On arm64 hosts with native AArch32
    support this runs natively; the container installs the required
    `libicu74`/`libatomic1` runtime deps and passes `RUNNER_ALLOW_RUNASROOT=1`
    for the root container user.

The armv7l binary can't `exec` on a bare arm64 host (no
`ld-linux-armhf.so.3`), which is why the direct `config.sh` call fails there;
the container provides the 32-bit userspace.

## Result

Runner CD can build and publish `actions-runner-linux-arm-<version>.tar.gz`
using the existing arm64 self-hosted runners — no dedicated armhf runner
required. This unblocks cutting a release whose latest asset set includes
`linux-arm`, which the image-builder consumes.

## Testing

The Package Release / Test package steps are gated `if: github.event_name !=
'pull_request'`, and the whole Runner CD run is gated by the `check` job
(`releaseVersion` must equal `src/runnerversion`). There is **no side-effect-free
dry run**: making `check` pass would proceed to the `release` job and cut an
actual public release. So this PR is not validated by a throwaway dispatch.

Confidence instead rests on:
- The `linux-arm` **build + layout + package** steps here are byte-identical to
  those in `build.yml`, which run on the same arm64 self-hosted pool.
- The new **arm32v7 container Test package** step is copied verbatim from the
  merged, dispatch-validated #169 (that run built the arm package and printed
  `config.sh --version` → `2.335.0` from inside the container).

The genuine end-to-end validation is the first real release cut from a
`releases/**` branch after this merges — at which point the `linux-arm` leg
will build on arm64 and smoke-test in the container just like Runner CI.
