### PR TITLE
fix: hard-fail patch_update_release.yml when any arch fails to regenerate

### DIFF
--- a/.github/workflows/patch_update_release.yml
+++ b/.github/workflows/patch_update_release.yml
@@ -79,17 +79,17 @@ jobs:
             # Check if previous patch exists
             if [ ! -f "../patches/runner-sdk8-$arch.patch" ] || \
                ! grep -q "${{ steps.get-tags.outputs.PREVIOUS_TAG }}" "../patches/runner-sdk8-$arch.patch"; then
-              echo "No valid previous patch for $arch"
+              echo "::error::No valid previous patch for $arch — patch file missing or does not reference ${{ steps.get-tags.outputs.PREVIOUS_TAG }}"
               cd ..
-              continue
+              exit 1
             fi
 
             # Apply previous patch to previous release
             git checkout ${{ steps.get-tags.outputs.PREVIOUS_TAG }}
             if ! git apply --check --whitespace=nowarn "../patches/runner-sdk8-$arch.patch"; then
-              echo "::warning::Previous patch application failed for $arch"
+              echo "::error::Previous patch application failed for $arch — patch does not apply cleanly to ${{ steps.get-tags.outputs.PREVIOUS_TAG }}"
               cd ..
-              continue
+              exit 1
             fi
             git apply --whitespace=nowarn "../patches/runner-sdk8-$arch.patch"
             
@@ -99,11 +99,11 @@ jobs:
             # Apply to latest release
             git checkout ${{ steps.get-tags.outputs.LATEST_TAG }}
             if ! git stash apply stash^{/patch-$arch}; then
-              echo "::warning::Stash application failed for $arch on ${{ steps.get-tags.outputs.LATEST_TAG }}"
+              echo "::error::Stash application failed for $arch on ${{ steps.get-tags.outputs.LATEST_TAG }} — patch conflicts with upstream changes; manual regeneration required"
               git reset --hard
               git stash drop || true
               cd ..
-              continue
+              exit 1
             fi
             
             # Create new patch


### PR DESCRIPTION
## Problem

The `patch_update_release.yml` workflow silently skipped architecture-patch regeneration failures using `continue`, allowing a PR and release branch to be created with stale patches. When `Runner CD` ran against a stale patch, the build cascade-canceled and no release was published — with no alert fired (the workflow exited 0). This is what happened with the v2.336.0 release (the ARM patch had a conflict that was silently skipped).

[PR #190](https://github.com/canonical/github-actions-runner/pull/190) fixed the same issue in `patch_update_main.yml` (commit-to-commit workflow). This PR applies the identical fix to its sibling `patch_update_release.yml` (release-to-release workflow), which was left unchanged.

## Solution

Replace every `continue` in the architecture-processing loop with `exit 1`, and every `::warning::` with `::error::` including the specific cause. Now any patch regeneration failure:

- Surfaces clearly via `::error::` annotations with the specific cause
- Fires the existing Mattermost alert on `failure()`
- Prevents the broken release branch from being pushed
- Leaves `last_processed_tag.txt` unchanged so the next scheduled run retries

## Related

- PR #190 — identical fix for `patch_update_main.yml` (commit-to-commit)